### PR TITLE
feat: added support for non-fhs systems

### DIFF
--- a/pulsecontrol/adapter.py
+++ b/pulsecontrol/adapter.py
@@ -9,11 +9,11 @@ class DriverException(Exception):
 
 
 def _execute_pactl(cmd: str) -> str:
+    bash_command = '/usr/bin/env bash -c "pactl {}"'.format(cmd)
     process = run(
-        'pactl {}'.format(cmd),
+        bash_command,
         capture_output=True,
-        shell=True,
-        executable='/bin/bash'
+        shell=True
     )
     if process.returncode != 0:
         raise DriverException(error_code=process.returncode, reason=process.stderr.decode('ascii'))


### PR DESCRIPTION
Hey @YetAnotherSimon !

First of all, thank you for making this very useful plugin.
This is a small change to support non-FHS systems (like [NixOS](https://en.wikipedia.org/wiki/NixOS)) where `bash` bin is located not in `/bin/bash`, but in `/run/current-system/sw/bin/bash`. This change makes it universally compatible with [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard) and non-FHS systems, so anyone can enjoy it.
Please let me know if you have any questions or concerns.

Thank you!